### PR TITLE
Use interface

### DIFF
--- a/examples/helloworld/process-starter.py
+++ b/examples/helloworld/process-starter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import division, print_function, absolute_import, unicode_literals
 import argparse, os, sys, re, fcntl, time, subprocess, textwrap, threading, signal
 

--- a/examples/helloworld/src/pages/About.tsx
+++ b/examples/helloworld/src/pages/About.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Head } from '@inertiajs/inertia-react';
+import {Head, Link} from '@inertiajs/inertia-react';
 
 export default function About() {
   return (
@@ -9,6 +9,9 @@ export default function About() {
       </Head>
       <div>
         About us
+        <div>
+          <Link href="/">Index</Link>
+        </div>
       </div>
     </>
   )

--- a/examples/helloworld/src/pages/Index.tsx
+++ b/examples/helloworld/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Head } from '@inertiajs/inertia-react';
+import { Head, Link } from '@inertiajs/inertia-react';
 
 type IndexProps = {
   message: string;
@@ -13,6 +13,9 @@ export default function Index({ message }: IndexProps) {
       </Head>
       <div>
         {message}
+        <div>
+          <Link href="/about">About us</Link>
+        </div>
       </div>
     </>
   )

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -15,13 +15,13 @@ func TestInertia_Version(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	inertia := New(c, "app.html", map[string]interface{}{}, nil)
+	in := New(c, "app.html", map[string]interface{}{}, nil)
 
-	inertia.SetVersion(func() string {
+	in.SetVersion(func() string {
 		return "123456789"
 	})
 
-	v := inertia.Version()
+	v := in.Version()
 	if v != "123456789" {
 		t.Errorf("inertia.Version() = %v, want %v", v, "1")
 	}
@@ -32,9 +32,9 @@ func TestInertia_SetRootView(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	inertia := New(c, "app.html", map[string]interface{}{}, nil)
-	inertia.SetRootView("app2.html")
-	if inertia.rootView != "app2.html" {
+	in := New(c, "app.html", map[string]interface{}{}, nil)
+	in.SetRootView("app2.html")
+	if in.RootView() != "app2.html" {
 		t.Fatal("rootView should be app2.html")
 	}
 }
@@ -48,11 +48,11 @@ func TestInertia_Render(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		inertia := New(c, "app.html", map[string]interface{}{}, func() string {
+		in := New(c, "app.html", map[string]interface{}{}, func() string {
 			return "123456789"
 		})
 
-		err := inertia.Render(http.StatusOK, "Home", map[string]interface{}{
+		err := in.Render(http.StatusOK, "Home", map[string]interface{}{
 			"title": "Home Page title",
 		})
 		if err != nil {
@@ -75,11 +75,11 @@ func TestInertia_Render(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		inertia := New(c, "app.html", map[string]interface{}{}, func() string {
+		in := New(c, "app.html", map[string]interface{}{}, func() string {
 			return "123456789"
 		})
 
-		err := inertia.Render(http.StatusOK, "Home", map[string]interface{}{
+		err := in.Render(http.StatusOK, "Home", map[string]interface{}{
 			"title": "Home Page title",
 		})
 		if err != nil {
@@ -102,11 +102,11 @@ func TestInertia_RenderWithViewData(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	inertia := New(c, "app_with_view_data.html", map[string]interface{}{}, func() string {
+	in := New(c, "app_with_view_data.html", map[string]interface{}{}, func() string {
 		return "123456789"
 	})
 
-	err := inertia.RenderWithViewData(http.StatusOK, "Home", map[string]interface{}{
+	err := in.RenderWithViewData(http.StatusOK, "Home", map[string]interface{}{
 		"title": "Home Page title",
 	}, map[string]interface{}{
 		"viewData": "This is view data",

--- a/middleware.go
+++ b/middleware.go
@@ -85,8 +85,8 @@ func MiddlewareWithConfig(config MiddlewareConfig) echo.MiddlewareFunc {
 			}
 
 			// Create an inertia instance.
-			inertia := New(c, config.RootView, sharedProps, config.VersionFunc)
-			c.Set(key, inertia)
+			in := New(c, config.RootView, sharedProps, config.VersionFunc)
+			c.Set(key, in)
 
 			req := c.Request()
 			res := c.Response()
@@ -99,8 +99,8 @@ func MiddlewareWithConfig(config MiddlewareConfig) echo.MiddlewareFunc {
 			// In the event that the assets change, initiate a
 			// client-side location visit to force an update.
 			// see https://inertiajs.com/the-protocol#asset-versioning
-			if checkVersion(req, inertia.Version()) {
-				return inertia.Location(req.URL.Path)
+			if checkVersion(req, in.Version()) {
+				return in.Location(req.URL.Path)
 			}
 
 			// Wrap the http response writer for modify the response headers after handler execution.
@@ -146,26 +146,26 @@ func changeRedirectCode(req *http.Request, res *echo.Response) {
 }
 
 var (
-	ErrNotFound = errors.New("context does not have '*Inertia'")
+	ErrNotFound = errors.New("context does not have 'Inertia'")
 )
 
-func Get(c echo.Context) (*Inertia, error) {
-	i, ok := c.Get(key).(*Inertia)
+func Get(c echo.Context) (Inertia, error) {
+	in, ok := c.Get(key).(Inertia)
 	if !ok {
 		return nil, ErrNotFound
 	}
-	return i, nil
+	return in, nil
 }
 
-func MustGet(c echo.Context) *Inertia {
-	i, err := Get(c)
+func MustGet(c echo.Context) Inertia {
+	in, err := Get(c)
 	if err != nil {
 		panic(err)
 	}
-	return i
+	return in
 }
 
 func Has(c echo.Context) bool {
-	_, ok := c.Get(key).(*Inertia)
+	_, ok := c.Get(key).(Inertia)
 	return ok
 }


### PR DESCRIPTION
I changed `Inertia` type from struct to interface. It makes your code that uses 'inertia-echo' testable. 
For example, if you want to test echo handler implementation with `inertia-echo`, you can mock the `Inertia` object. It is useful because you don't need to run a real render function.