### PR TITLE
use specified status code for inertia response

### DIFF
--- a/inertia.go
+++ b/inertia.go
@@ -2,7 +2,6 @@ package inertia
 
 import (
 	"bytes"
-	"net/http"
 	"sync"
 
 	"github.com/labstack/echo/v4"
@@ -155,7 +154,7 @@ func (i *Inertia) render(code int, component string, props, viewData map[string]
 
 	if req.Header.Get(HeaderXInertia) != "" {
 		res.Header().Set(HeaderXInertia, "true")
-		return c.JSON(http.StatusOK, page)
+		return c.JSON(code, page)
 	}
 
 	viewData["page"] = page


### PR DESCRIPTION
In the current implementation, the Inertia JSON response is always returned with an HTTP 200 status code. This process is based on the Inertia-Laravel implementation. You can see this here:  see https://github.com/inertiajs/inertia-laravel/blob/af7571859cb643b206ff67083d47fb75cd7f26de/src/Response.php#L107

However, I believe it would be better to return different status codes under certain circumstances, such as a 404 error.

I have tested this and confirmed that the Inertia client-side library can accept status codes other than 200.