### PR TITLE
Update lazyprops

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,17 +127,23 @@ inertia.Render(c, http.StatusOK, "Index", map[string]interface{}{
 	// ALWAYS included on first visit...
 	// OPTIONALLY included on partial reloads...
 	// ONLY evaluated when needed...
-	"users": func() interface{} {
-		users := // get users...
+	"users": func() (interface{}, error) {
+    users, err := // get users...
+    if err != nil {
+        return nil, err
+    }
 		return users
 	},
 
 	// NEVER included on first visit
 	// OPTIONALLY included on partial reloads
 	// ONLY evaluated when needed
-	"users": inertia.Lazy(func() interface{} {
-		users := // get users...
-		return users
+	"users": inertia.Lazy(func() (interface{}, error) {
+		users, err := // get users...
+		if err != nil {
+      return nil, err
+    }
+		return users, nil
 	}),
 })
 ```

--- a/inertia.go
+++ b/inertia.go
@@ -146,7 +146,9 @@ func (i *Inertia) render(code int, component string, props, viewData map[string]
 		props = filteredProps
 	}
 
-	evaluateProps(props)
+	if err := evaluateProps(props); err != nil {
+		return err
+	}
 
 	page := &Page{
 		Component: component,
@@ -179,13 +181,15 @@ func (i *Inertia) renderHTML(code int, name string, data map[string]interface{})
 	return i.c.HTMLBlob(code, buf.Bytes())
 }
 
+type LazyPropFunc func() (interface{}, error)
+
 type LazyProp struct {
-	callback func() interface{}
+	callback LazyPropFunc
 }
 
 // Lazy defines a lazy evaluated data.
 // see https://inertiajs.com/partial-reloads#lazy-data-evaluation
-func Lazy(callback func() interface{}) *LazyProp {
+func Lazy(callback LazyPropFunc) *LazyProp {
 	return &LazyProp{
 		callback: callback,
 	}

--- a/inertia_test.go
+++ b/inertia_test.go
@@ -239,8 +239,8 @@ func TestInertia_Render(t *testing.T) {
 			"key2": func() interface{} {
 				return "value2"
 			},
-			"key3": Lazy(func() interface{} {
-				return "value3"
+			"key3": Lazy(func() (interface{}, error) {
+				return "value3", nil
 			}),
 		})
 		if err != nil {
@@ -288,8 +288,8 @@ func TestInertia_Render(t *testing.T) {
 			"key2": func() interface{} {
 				return "value2"
 			},
-			"key3": Lazy(func() interface{} {
-				return "value3"
+			"key3": Lazy(func() (interface{}, error) {
+				return "value3", nil
 			}),
 		})
 		if err != nil {

--- a/util_test.go
+++ b/util_test.go
@@ -119,8 +119,8 @@ func TestEvaluateProps(t *testing.T) {
 				"b-b-a": "b-b-aaa",
 			},
 		},
-		"c": Lazy(func() interface{} {
-			return "ccc"
+		"c": Lazy(func() (interface{}, error) {
+			return "ccc", nil
 		}),
 		"d": func() interface{} {
 			return "ddd"


### PR DESCRIPTION
BREAKING CHANGE: After this update,  both inertia.Lazy and functions passed as props can return errors. Lazy data evaluation, which is often used in database access code, might lead to errors. This update provides handling for these errors.